### PR TITLE
Add initial Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: perl
+
 perl:
-  - "5.26"
-  - "5.24"
-  - "5.22"
-  - "5.20"
-  - "5.6.2"
-before_install:  cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
-  
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Module::Install
+    - cpanm --installdeps .


### PR DESCRIPTION
This is just an initial configuration which is able to test Perls 5.10 .. 5.26.  It would be good to include other Perls via the Travis-CI helpers, however this is a start in the right direction.  This patch would close issue #1.